### PR TITLE
Add Instant Activation Option

### DIFF
--- a/GW2-RadialMenus.vcxproj
+++ b/GW2-RadialMenus.vcxproj
@@ -139,6 +139,7 @@ CALL $(SolutionDir)Scripts\version.bat</Command>
     <ClCompile Include="src\Core\Addon.cpp" />
     <ClCompile Include="src\Core\Conditions.cpp" />
     <ClCompile Include="src\Core\RadialContext.cpp" />
+    <ClCompile Include="src\Core\RadialItem.cpp" />
     <ClCompile Include="src\Core\StateObserver.cpp" />
     <ClCompile Include="src\entry.cpp" />
     <ClCompile Include="src\imgui_extensions.cpp" />

--- a/GW2-RadialMenus.vcxproj.filters
+++ b/GW2-RadialMenus.vcxproj.filters
@@ -170,6 +170,9 @@
     <ClCompile Include="src\Core\Conditions.cpp">
       <Filter>Core\Structs</Filter>
     </ClCompile>
+    <ClCompile Include="src\Core\RadialItem.cpp">
+      <Filter>Core\Structs</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="src\Resources\MW_5_SELECTOR.png">

--- a/RadialItem.cpp
+++ b/RadialItem.cpp
@@ -1,0 +1,5 @@
+#include "RadialItem.h"
+
+void RadialMenuItem::Activate(AddonAPI* API) {
+
+}

--- a/RadialItem.cpp
+++ b/RadialItem.cpp
@@ -1,5 +1,0 @@
-#include "RadialItem.h"
-
-void RadialMenuItem::Activate(AddonAPI* API) {
-
-}

--- a/src/Core/RadialContext.cpp
+++ b/src/Core/RadialContext.cpp
@@ -839,6 +839,7 @@ void CRadialContext::RenderOptions()
 
 		ImGui::Checkbox("Draw in Center", &this->EditingMenu->DrawInCenter);
 		ImGui::Checkbox("Restore Cursor Position", &this->EditingMenu->RestoreCursor);
+		ImGui::Checkbox("Instant Activate if only one Item visible", &this->EditingMenu->InstantActivation);
 	}
 	else if (this->EditingItem) /* editing sub item */
 	{
@@ -1516,6 +1517,8 @@ void CRadialContext::LoadInternal()
 			if (!radialData["DrawInCenter"].is_null()) { radialData["DrawInCenter"].get_to(drawInCenter); }
 			bool restoreCursor = false;
 			if (!radialData["RestoreCursor"].is_null()) { radialData["RestoreCursor"].get_to(restoreCursor); }
+			bool instantActivation = false;
+			if (!radialData["InstantActivation"].is_null()) { radialData["InstantActivation"].get_to(instantActivation); }
 			float scale = 1.0f;
 			if (!radialData["Scale"].is_null()) { radialData["Scale"].get_to(scale); }
 			int hoverTimeout = 0;
@@ -1536,6 +1539,7 @@ void CRadialContext::LoadInternal()
 			CRadialMenu* radial = this->Add(filePath, name, type, selMode, id);
 			radial->DrawInCenter = drawInCenter;
 			radial->RestoreCursor = restoreCursor;
+			radial->InstantActivation = instantActivation;
 			radial->Scale = scale;
 			radial->HoverTimeout = hoverTimeout;
 			radial->ItemRotationDegrees = itemRotation;

--- a/src/Core/RadialContext.cpp
+++ b/src/Core/RadialContext.cpp
@@ -839,7 +839,8 @@ void CRadialContext::RenderOptions()
 
 		ImGui::Checkbox("Draw in Center", &this->EditingMenu->DrawInCenter);
 		ImGui::Checkbox("Restore Cursor Position", &this->EditingMenu->RestoreCursor);
-		ImGui::Checkbox("Instant Activate if only one Item visible", &this->EditingMenu->InstantActivation);
+		ImGui::Checkbox("Instant Activation for single Items", &this->EditingMenu->InstantActivation);
+		ImGui::HelpMarker("If due to filter conditions only one item would be visible,\ninstantly activate that Item wihtout showing a menu");
 	}
 	else if (this->EditingItem) /* editing sub item */
 	{

--- a/src/Core/RadialItem.cpp
+++ b/src/Core/RadialItem.cpp
@@ -1,0 +1,123 @@
+#include "RadialItem.h"
+#include <Util.h>
+#include "StateObserver.h"
+#include <thread>
+
+void RadialMenuItem::Activate(AddonAPI* API) {
+
+	std::thread([this, API]() {
+		/* FIXME: this needs to be able to abort if another item is selected halfway through execution */
+		int msWaited = 0;
+		while (!StateObserver::IsMatch(&this->Activation))
+		{
+			msWaited += 100;
+			Sleep(100);
+
+			if (msWaited > this->ActivationTimeout * 1000) { break; }
+		}
+
+		if (msWaited > this->ActivationTimeout * 1000)
+		{
+			API->UI.SendAlert("Cancelled after waiting for timeout.");
+			return;
+		}
+
+		/* initially set to true, and only in the skip set to false, this way the first action ignores the setting */
+		bool previousExecuted = true;
+		for (ActionBase* act : this->Actions)
+		{
+			if (!StateObserver::IsMatch(&act->Activation))
+			{
+				previousExecuted = false;
+				continue;
+			}
+
+			if (act->OnlyExecuteIfPrevious && !previousExecuted)
+			{
+				previousExecuted = false;
+				continue;
+			}
+
+			switch (act->Type)
+			{
+			case EActionType::InputBind:
+			{
+				ActionGeneric* action = (ActionGeneric*)act;
+				API->InputBinds.Invoke(action->Identifier.c_str(), false);
+				API->InputBinds.Invoke(action->Identifier.c_str(), true);
+				break;
+			}
+			case EActionType::GameInputBind:
+			{
+				ActionGameInputBind* action = (ActionGameInputBind*)act;
+				/* FIXME: all of the following code is acopy of the Nexus Invoke function. Nexus does not provide Invoke only InvokeAsync.*/
+				/* get modifier state */
+				bool wasAltPressed = GetAsyncKeyState(VK_MENU);
+				bool wasCtrlPressed = GetAsyncKeyState(VK_CONTROL);
+				bool wasShiftPressed = GetAsyncKeyState(VK_SHIFT);
+
+				/* unset modifier state */
+				if (wasAltPressed)
+				{
+					API->WndProc.SendToGameOnly(0, WM_SYSKEYUP, VK_MENU, Input::GetKeyMessageLPARAM(VK_MENU, false, true));
+				}
+				if (wasCtrlPressed)
+				{
+					API->WndProc.SendToGameOnly(0, WM_KEYUP, VK_CONTROL, Input::GetKeyMessageLPARAM(VK_CONTROL, false, false));
+				}
+				if (wasShiftPressed)
+				{
+					API->WndProc.SendToGameOnly(0, WM_KEYUP, VK_SHIFT, Input::GetKeyMessageLPARAM(VK_SHIFT, false, false));
+				}
+
+				/* execute action action */
+				API->GameBinds.Press(action->Identifier);
+				Sleep(100);
+				API->GameBinds.Release(action->Identifier);
+
+				/* restore modifier state */
+				if (GetAsyncKeyState(VK_MENU))
+				{
+					API->WndProc.SendToGameOnly(0, WM_SYSKEYDOWN, VK_MENU, Input::GetKeyMessageLPARAM(VK_MENU, true, true));
+				}
+				if (GetAsyncKeyState(VK_CONTROL))
+				{
+					API->WndProc.SendToGameOnly(0, WM_KEYDOWN, VK_CONTROL, Input::GetKeyMessageLPARAM(VK_CONTROL, true, false));
+				}
+				if (GetAsyncKeyState(VK_SHIFT))
+				{
+					API->WndProc.SendToGameOnly(0, WM_KEYDOWN, VK_SHIFT, Input::GetKeyMessageLPARAM(VK_SHIFT, true, false));
+				}
+				break;
+			}
+			case EActionType::GameInputBindPress:
+			{
+				ActionGameInputBind* action = (ActionGameInputBind*)act;
+				API->GameBinds.Press(action->Identifier);
+				break;
+			}
+			case EActionType::GameInputBindRelease:
+			{
+				ActionGameInputBind* action = (ActionGameInputBind*)act;
+				API->GameBinds.Release(action->Identifier);
+				break;
+			}
+			case EActionType::Event:
+			{
+				ActionGeneric* action = (ActionGeneric*)act;
+				API->Events.Raise(action->Identifier.c_str(), nullptr);
+				break;
+			}
+			case EActionType::Delay:
+			{
+				ActionDelay* action = (ActionDelay*)act;
+				Sleep(action->Duration);
+				break;
+			}
+			}
+
+			previousExecuted = true;
+		}
+	}).detach();
+
+}

--- a/src/Core/RadialItem.h
+++ b/src/Core/RadialItem.h
@@ -21,6 +21,8 @@ typedef struct RadialItem
 	Conditions               Activation;
 	int                      ActivationTimeout;
 	std::vector<ActionBase*> Actions;
+
+	void Activate(AddonAPI* API);
 } RadialMenuItem;
 
 #endif

--- a/src/Core/RadialMenu.h
+++ b/src/Core/RadialMenu.h
@@ -30,7 +30,7 @@ class CRadialMenu
 	public:
 	bool                        DrawInCenter;
 	bool                        RestoreCursor;
-	bool						InstantActivation;
+	bool                        InstantActivation;
 	float                       Scale;
 	int                         HoverTimeout;
 	int                         ItemRotationDegrees;

--- a/src/Core/RadialMenu.h
+++ b/src/Core/RadialMenu.h
@@ -30,6 +30,7 @@ class CRadialMenu
 	public:
 	bool                        DrawInCenter;
 	bool                        RestoreCursor;
+	bool						InstantActivation;
 	float                       Scale;
 	int                         HoverTimeout;
 	int                         ItemRotationDegrees;


### PR DESCRIPTION
This factors out Item activation into the Item struct and provides an option to instantly activate an item without showing a menu.

Usefull for stuff like mounts (eg, wvw only has one option, so you could reuse the keybind for the radial to just toggle mount)